### PR TITLE
containerコンポーネント作成

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -52,7 +52,7 @@ config/*
 bin/*
 
 # typed scss modules
-**/*modules.scss.d.ts
+**/*module.scss.d.ts
 
 # PWA
 **/public/sw.js

--- a/front/src/components/Containers/Container.tsx
+++ b/front/src/components/Containers/Container.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import styles from '@/styles/components/Containers/Container.module.scss'
+
+type ContainerProps = {
+  children: React.ReactNode
+}
+
+export const Container = ({ children }: ContainerProps) => {
+  return <div className={styles.container}>{children}</div>
+}

--- a/front/src/components/Containers/index.ts
+++ b/front/src/components/Containers/index.ts
@@ -1,0 +1,1 @@
+export { Container } from '@/components/Containers/Container'

--- a/front/src/stories/components/Containers/Container.stories.tsx
+++ b/front/src/stories/components/Containers/Container.stories.tsx
@@ -1,0 +1,20 @@
+import { StoryObj, ComponentMeta } from '@storybook/react'
+import { Container } from '@/components/Containers'
+
+export default {
+  component: Container,
+  argTypes: {
+    children: {
+      description: '任意のコンポーネントが入ります'
+    }
+  },
+  render: ({ children }) => {
+    return <Container>{children}</Container>
+  }
+} as ComponentMeta<typeof Container>
+
+export const Default: StoryObj = {
+  args: {
+    children: <h1>Welcome to traveli!</h1>
+  }
+}

--- a/front/src/styles/components/Containers/Container.module.scss
+++ b/front/src/styles/components/Containers/Container.module.scss
@@ -1,0 +1,9 @@
+@use '@/styles/variables' as v;
+
+.container {
+  max-width: map-get(v.$breakpoints, 'md');
+  min-width: map-get(v.$breakpoints, 'sm');
+  margin: 0 auto;
+  padding: 0 1.6rem;
+  min-height: 100vh;
+}

--- a/front/src/styles/variables.scss
+++ b/front/src/styles/variables.scss
@@ -1,0 +1,4 @@
+$breakpoints: (
+  sm: 32rem,
+  md: 68rem,
+);


### PR DESCRIPTION
## 💫 関連Issues
close #10 

## 💪🏻 変更したこと
- コンテナコンポーネント作成
  - 常に左右に16pxの余白がつく
  - 画面サイズが大きくても，680px以上は広がらない
- Storybook作成
- gitignoreミスってたので修正
  - scssの型ファイルを無視するように

## 👀 確認項目
- http://localhost:6006/?path=/story/stories-components-containers-container--default
  - タブレットサイズとかスマホサイズとか色々いじって確認してください！