### PR TITLE
👂 リスト表示グリッド表示切り替え

### DIFF
--- a/front/src/components/Cards/CardTravelink.tsx
+++ b/front/src/components/Cards/CardTravelink.tsx
@@ -11,15 +11,15 @@ type CardTravelinkProps = {
   }
 }
 
-export const CardTravelink = ({ data }: CardTravelinkProps) => {
+export const CardTravelink = ({ data, isSquare }: CardTravelinkProps) => {
   return (
     <div css={styles.wrapper}>
-      <div css={styles.imgWrapper}>
+      <div css={styles.imgWrapper(isSquare)}>
         <Image alt="" css={styles.img} fill src={data.thumbnail} />
       </div>
-      <div css={styles.description}>
-        <h2 css={styles.title}>{data.title}</h2>
-        <p css={styles.date}>{data.date}</p>
+      <div css={styles.description(isSquare)}>
+        <h2 css={styles.title(isSquare)}>{data.title}</h2>
+        <p css={styles.date(isSquare)}>{data.date}</p>
       </div>
     </div>
   )

--- a/front/src/components/Cards/CardTravelink.tsx
+++ b/front/src/components/Cards/CardTravelink.tsx
@@ -3,7 +3,7 @@ import { styles } from '@/styles/components/Cards/CardTravelink.styles'
 
 // 仮置きの型設定
 type CardTravelinkProps = {
-  isSquare: boolean
+  isGrid: boolean
   data: {
     thumbnail: string
     date?: [string, string]
@@ -11,15 +11,15 @@ type CardTravelinkProps = {
   }
 }
 
-export const CardTravelink = ({ data, isSquare }: CardTravelinkProps) => {
+export const CardTravelink = ({ data, isGrid }: CardTravelinkProps) => {
   return (
     <div css={styles.wrapper}>
-      <div css={[styles.imgWrapper(isSquare), isSquare && styles.imgSquare]}>
+      <div css={[styles.imgWrapper(isGrid), isGrid && styles.imgSquare]}>
         <Image alt="" css={styles.img} fill src={data.thumbnail} />
       </div>
-      <div css={styles.description(isSquare)}>
-        <h2 css={styles.title(isSquare)}>{data.title}</h2>
-        <p css={styles.date(isSquare)}>{data.date}</p>
+      <div css={styles.description(isGrid)}>
+        <h2 css={styles.title(isGrid)}>{data.title}</h2>
+        <p css={styles.date(isGrid)}>{data.date}</p>
       </div>
     </div>
   )

--- a/front/src/components/Cards/CardTravelink.tsx
+++ b/front/src/components/Cards/CardTravelink.tsx
@@ -1,54 +1,26 @@
 import Image from 'next/image'
-import Link from 'next/link'
-import { AvatarWithText } from '@/components/Avatars'
-import { ChipTag } from '@/components/Chips'
-import type {
-  FavoriteDataType,
-  TravelinkDataType
-} from '@/components/Tabs/TabHome'
 import { styles } from '@/styles/components/Cards/CardTravelink.styles'
 
 // 仮置きの型設定
 type CardTravelinkProps = {
-  travelink?: TravelinkDataType
-  favorite?: FavoriteDataType
+  isSquare: boolean
+  data: {
+    thumbnail: string
+    date?: [string, string]
+    title: string
+  }
 }
 
-export const CardTravelink = ({ travelink, favorite }: CardTravelinkProps) => {
+export const CardTravelink = ({ data }: CardTravelinkProps) => {
   return (
-    <>
-      {travelink && (
-        <Link css={styles.wrapper} href="/">
-          <div css={styles.imgWrapper}>
-            <Image alt="img" css={styles.img} fill src={travelink.thumbnail} />
-          </div>
-          <div css={styles.content}>
-            <p css={styles.title}>{travelink.title}</p>
-            <p css={styles.day}>
-              {travelink.date[0]} - {travelink.date[1]}
-            </p>
-            <div css={styles.layoutAvatarWithText}>
-              <AvatarWithText
-                name={travelink.ownerName}
-                url={travelink.thumbnail}
-              />
-            </div>
-          </div>
-        </Link>
-      )}
-      {favorite && (
-        <Link css={styles.wrapper} href="/">
-          <div css={styles.imgWrapper}>
-            <Image alt="img" css={styles.img} fill src={favorite.thumbnail} />
-          </div>
-          <div css={styles.content}>
-            <p css={styles.title}>{favorite.title}</p>
-            <div css={styles.layoutChipTag}>
-              <ChipTag css={styles.layoutChipTag} tag={favorite.tag} />
-            </div>
-          </div>
-        </Link>
-      )}
-    </>
+    <div css={styles.wrapper}>
+      <div css={styles.imgWrapper}>
+        <Image alt="" css={styles.img} fill src={data.thumbnail} />
+      </div>
+      <div css={styles.description}>
+        <h2 css={styles.title}>{data.title}</h2>
+        <p css={styles.date}>{data.date}</p>
+      </div>
+    </div>
   )
 }

--- a/front/src/components/Cards/CardTravelink.tsx
+++ b/front/src/components/Cards/CardTravelink.tsx
@@ -14,7 +14,7 @@ type CardTravelinkProps = {
 export const CardTravelink = ({ data, isSquare }: CardTravelinkProps) => {
   return (
     <div css={styles.wrapper}>
-      <div css={styles.imgWrapper(isSquare)}>
+      <div css={[styles.imgWrapper(isSquare), isSquare && styles.imgSquare]}>
         <Image alt="" css={styles.img} fill src={data.thumbnail} />
       </div>
       <div css={styles.description(isSquare)}>

--- a/front/src/components/Tabs/TabHome.tsx
+++ b/front/src/components/Tabs/TabHome.tsx
@@ -1,46 +1,28 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { CardTravelink } from '@/components/Cards'
 import { styles } from '@/styles/components/Tabs/TabHome.styles'
 
-// 仮置きの型設定
-// TODO:本実装のタイミングでtypeの内容とexport場所を変更
-export type TravelinkDataType = {
-  id: string
-  ownerId: string
-  title: string
-  thumbnail: string
-  date: string[]
-  ownerName: string
-  ownerIcon: string
-}
-
-// 仮置きの型設定
-// TODO:本実装のタイミングでtypeの内容とexport場所を変更
-export type FavoriteDataType = {
-  puclicId: string
-  title: string
-  thumbnail: string
-  tag: string[]
-}
-
 type TabHomeProps = {
-  userId: string
-  myTravelinkList: TravelinkDataType[]
-  favoriteList: FavoriteDataType[]
+  data: {
+    id: string
+    ownerId: string
+    title: string
+    thumbnail: string
+    date: [string, string]
+    ownerName: string
+    ownerIcon: string
+  }[]
 }
 
-export const TabHome = ({
-  userId,
-  myTravelinkList,
-  favoriteList
-}: TabHomeProps) => {
+export const TabHome = ({ data }: TabHomeProps) => {
   const [value, setValue] = useState<string>('all')
-  const [joinedList, setJoinedList] = useState<TravelinkDataType[]>([])
 
-  useEffect(() => {
-    const list = myTravelinkList.filter((item) => item.ownerId !== userId)
-    if (list) setJoinedList(list)
-  }, [])
+  const travelinkData = data.map(({ thumbnail, date, title, id }) => ({
+    thumbnail,
+    date,
+    title,
+    id
+  }))
 
   return (
     <>
@@ -82,11 +64,11 @@ export const TabHome = ({
       </div>
       {value === 'all' && (
         <>
-          {myTravelinkList.length ? (
+          {travelinkData.length ? (
             <>
-              {myTravelinkList.map((travelink) => (
+              {travelinkData.map((travelink) => (
                 <div css={styles.layoutCardTravelink} key={travelink.id}>
-                  <CardTravelink travelink={travelink} />
+                  <CardTravelink data={travelink} isSquare={false} />
                 </div>
               ))}
             </>
@@ -97,40 +79,8 @@ export const TabHome = ({
           )}
         </>
       )}
-      {value === 'join' && (
-        <>
-          {joinedList.length ? (
-            <>
-              {joinedList.map((item) => (
-                <div css={styles.layoutCardTravelink} key={item.id}>
-                  <CardTravelink travelink={item} />
-                </div>
-              ))}
-            </>
-          ) : (
-            <>
-              <p>参加中のトラべリンクがないです</p>
-            </>
-          )}
-        </>
-      )}
-      {value === 'favorite' && (
-        <>
-          {favoriteList.length ? (
-            <>
-              {favoriteList.map((favorite) => (
-                <div css={styles.layoutCardTravelink} key={favorite.puclicId}>
-                  <CardTravelink favorite={favorite} />
-                </div>
-              ))}
-            </>
-          ) : (
-            <>
-              <p>いいねしたみんなのたびがないです</p>
-            </>
-          )}
-        </>
-      )}
+      {value === 'join' && <p>参加中のトラべリンクがないです</p>}
+      {value === 'favorite' && <p>いいねしたみんなのたびがないです</p>}
     </>
   )
 }

--- a/front/src/components/Tabs/TabHome.tsx
+++ b/front/src/components/Tabs/TabHome.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { HiViewGrid } from 'react-icons/hi'
+import { HiViewGrid, HiOutlineViewList } from 'react-icons/hi'
 import { CardTravelink } from '@/components/Cards'
 import { styles } from '@/styles/components/Tabs/TabHome.styles'
 
@@ -17,7 +17,7 @@ type TabHomeProps = {
 
 export const TabHome = ({ data }: TabHomeProps) => {
   const [value, setValue] = useState<string>('all')
-  const [isSquare, setIsSquare] = useState(false)
+  const [isGrid, setIsGrid] = useState(false)
 
   const travelinkData = data.map(({ thumbnail, date, title, id }) => ({
     thumbnail,
@@ -68,19 +68,19 @@ export const TabHome = ({ data }: TabHomeProps) => {
         <button
           css={styles.buttonGrid}
           onClick={() => {
-            setIsSquare(!isSquare)
+            setIsGrid(!isGrid)
           }}
         >
-          <HiViewGrid size={20} />
+          {isGrid ? <HiOutlineViewList size={20} /> : <HiViewGrid size={20} />}
         </button>
       </div>
       {value === 'all' && (
         <>
           {travelinkData.length ? (
-            <div css={styles.grid(isSquare)}>
+            <div css={styles.grid(isGrid)}>
               {travelinkData.map((travelink) => (
                 <div key={travelink.id}>
-                  <CardTravelink data={travelink} isSquare={isSquare} />
+                  <CardTravelink data={travelink} isGrid={isGrid} />
                 </div>
               ))}
             </div>

--- a/front/src/components/Tabs/TabHome.tsx
+++ b/front/src/components/Tabs/TabHome.tsx
@@ -75,7 +75,7 @@ export const TabHome = ({ data }: TabHomeProps) => {
           {travelinkData.length ? (
             <div css={styles.grid(isSquare)}>
               {travelinkData.map((travelink) => (
-                <div css={styles.layoutCardTravelink} key={travelink.id}>
+                <div key={travelink.id}>
                   <CardTravelink data={travelink} isSquare={isSquare} />
                 </div>
               ))}

--- a/front/src/components/Tabs/TabHome.tsx
+++ b/front/src/components/Tabs/TabHome.tsx
@@ -16,6 +16,7 @@ type TabHomeProps = {
 
 export const TabHome = ({ data }: TabHomeProps) => {
   const [value, setValue] = useState<string>('all')
+  const [isSquare, setIsSquare] = useState(false)
 
   const travelinkData = data.map(({ thumbnail, date, title, id }) => ({
     thumbnail,
@@ -26,6 +27,13 @@ export const TabHome = ({ data }: TabHomeProps) => {
 
   return (
     <>
+      <button
+        onClick={() => {
+          setIsSquare(!isSquare)
+        }}
+      >
+        きりかえ
+      </button>
       <div css={styles.tabs}>
         <label>
           <input
@@ -68,14 +76,12 @@ export const TabHome = ({ data }: TabHomeProps) => {
             <>
               {travelinkData.map((travelink) => (
                 <div css={styles.layoutCardTravelink} key={travelink.id}>
-                  <CardTravelink data={travelink} isSquare={false} />
+                  <CardTravelink data={travelink} isSquare={isSquare} />
                 </div>
               ))}
             </>
           ) : (
-            <>
-              <p>トラべリンクがないです</p>
-            </>
+            <p>トラべリンクがないです</p>
           )}
         </>
       )}

--- a/front/src/components/Tabs/TabHome.tsx
+++ b/front/src/components/Tabs/TabHome.tsx
@@ -73,13 +73,13 @@ export const TabHome = ({ data }: TabHomeProps) => {
       {value === 'all' && (
         <>
           {travelinkData.length ? (
-            <>
+            <div css={styles.grid(isSquare)}>
               {travelinkData.map((travelink) => (
                 <div css={styles.layoutCardTravelink} key={travelink.id}>
                   <CardTravelink data={travelink} isSquare={isSquare} />
                 </div>
               ))}
-            </>
+            </div>
           ) : (
             <p>トラべリンクがないです</p>
           )}

--- a/front/src/components/Tabs/TabHome.tsx
+++ b/front/src/components/Tabs/TabHome.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { HiViewGrid } from 'react-icons/hi'
 import { CardTravelink } from '@/components/Cards'
 import { styles } from '@/styles/components/Tabs/TabHome.styles'
 
@@ -27,48 +28,51 @@ export const TabHome = ({ data }: TabHomeProps) => {
 
   return (
     <>
-      <button
-        onClick={() => {
-          setIsSquare(!isSquare)
-        }}
-      >
-        きりかえ
-      </button>
-      <div css={styles.tabs}>
-        <label>
-          <input
-            defaultChecked
-            name="tab"
-            type="radio"
-            value="all"
-            onChange={(e) => {
-              setValue(e.target.value)
-            }}
-          />
-          <span>すべて</span>
-        </label>
-        <label>
-          <input
-            name="tab"
-            type="radio"
-            value="join"
-            onChange={(e) => {
-              setValue(e.target.value)
-            }}
-          />
-          <span>参加中</span>
-        </label>
-        <label>
-          <input
-            name="tab"
-            type="radio"
-            value="favorite"
-            onChange={(e) => {
-              setValue(e.target.value)
-            }}
-          />
-          <span>いいね</span>
-        </label>
+      <div css={styles.tabsWrapper}>
+        <div css={styles.tabs}>
+          <label>
+            <input
+              defaultChecked
+              name="tab"
+              type="radio"
+              value="all"
+              onChange={(e) => {
+                setValue(e.target.value)
+              }}
+            />
+            <span>すべて</span>
+          </label>
+          <label>
+            <input
+              name="tab"
+              type="radio"
+              value="join"
+              onChange={(e) => {
+                setValue(e.target.value)
+              }}
+            />
+            <span>参加中</span>
+          </label>
+          <label>
+            <input
+              name="tab"
+              type="radio"
+              value="favorite"
+              onChange={(e) => {
+                setValue(e.target.value)
+              }}
+            />
+            <span>いいね</span>
+          </label>
+        </div>
+        <button
+          css={styles.buttonGrid}
+          onClick={() => {
+            setIsSquare(!isSquare)
+          }}
+        >
+          <HiViewGrid size={20} />
+        </button>
       </div>
       {value === 'all' && (
         <>

--- a/front/src/pages/home/index.tsx
+++ b/front/src/pages/home/index.tsx
@@ -25,7 +25,7 @@ const Home = () => {
       ownerIcon: '/images/user_sample.jpeg'
     },
     {
-      id: 'def',
+      id: 'aie',
       ownerId: 'usagi',
       title: '鳥取４人旅',
       thumbnail: '/images/user_sample.jpeg',

--- a/front/src/pages/home/index.tsx
+++ b/front/src/pages/home/index.tsx
@@ -5,14 +5,13 @@ import { styles } from '@/styles/pages/home/index.styles'
 
 const Home = () => {
   // 仮置きのサンプルデータ
-  const userId = 'opanchu'
-  const myTravelinkList = [
+  const travelinkData = [
     {
       id: 'abc',
       ownerId: 'opanchu',
       title: 'いつメンの京都旅行',
       thumbnail: '/images/user_sample.jpeg',
-      date: ['2023.03.25', '2023.03.27'],
+      date: ['2023.03.25', '2023.03.27'] as [string, string],
       ownerName: 'おぱんちゅうさぎ',
       ownerIcon: '/images/user_sample.jpeg'
     },
@@ -21,34 +20,17 @@ const Home = () => {
       ownerId: 'usagi',
       title: '鳥取４人旅',
       thumbnail: '/images/user_sample.jpeg',
-      date: ['2023.03.25', '2023.03.27'],
+      date: ['2023.03.25', '2023.03.27'] as [string, string],
       ownerName: 'うさぎ',
       ownerIcon: '/images/user_sample.jpeg'
     }
   ]
-  const favoriteList = [
-    {
-      puclicId: '123',
-      title: 'コスパ重視の京都旅行',
-      tag: ['京都', '3人旅'],
-      thumbnail: '/images/user_sample.jpeg'
-    },
-    {
-      puclicId: '456',
-      title: 'うどん巡り四国旅',
-      tag: ['香川', '徳島', '愛媛', '高知', '2人旅'],
-      thumbnail: '/images/user_sample.jpeg'
-    }
-  ]
+
   return (
     <>
       <Container bgColor="white" isFull>
         <h1 css={styles.heading1}>私のトラべリンク</h1>
-        <TabHome
-          favoriteList={favoriteList}
-          myTravelinkList={myTravelinkList}
-          userId={userId}
-        />
+        <TabHome data={travelinkData} />
       </Container>
       <NavigationBottom />
     </>

--- a/front/src/pages/home/index.tsx
+++ b/front/src/pages/home/index.tsx
@@ -23,6 +23,15 @@ const Home = () => {
       date: ['2023.03.25', '2023.03.27'] as [string, string],
       ownerName: 'うさぎ',
       ownerIcon: '/images/user_sample.jpeg'
+    },
+    {
+      id: 'def',
+      ownerId: 'usagi',
+      title: '鳥取４人旅',
+      thumbnail: '/images/user_sample.jpeg',
+      date: ['2023.03.25', '2023.03.27'] as [string, string],
+      ownerName: 'うさぎ',
+      ownerIcon: '/images/user_sample.jpeg'
     }
   ]
 

--- a/front/src/stories/components/Cards/CardTravelink.stories.tsx
+++ b/front/src/stories/components/Cards/CardTravelink.stories.tsx
@@ -4,11 +4,8 @@ import type { StoryObj, Meta } from '@storybook/react'
 const meta: Meta<typeof CardTravelink> = {
   component: CardTravelink,
   argTypes: {
-    travelink: {
-      description: 'ユーザが作成、または、参加中のトラべリンクが入ります'
-    },
-    favorite: {
-      description: 'いいねしたみんなのたびトラべリンクが入ります'
+    data: {
+      description: 'title, thumbnail, date'
     }
   },
   tags: ['autodocs']
@@ -20,25 +17,10 @@ type Story = StoryObj<typeof CardTravelink>
 
 export const Default: Story = {
   args: {
-    travelink: {
-      id: 'abc',
-      ownerId: 'opanchu',
+    data: {
       title: 'いつメンの京都旅行',
       thumbnail: '/images/user_sample.jpeg',
-      date: ['2023.03.25', '2023.03.27'],
-      ownerName: 'おぱんちゅうさぎ',
-      ownerIcon: '/images/user_sample.jpeg'
-    }
-  }
-}
-
-export const Favorite: Story = {
-  args: {
-    favorite: {
-      puclicId: '123',
-      title: 'コスパ重視の京都旅行',
-      tag: ['京都', '3人旅'],
-      thumbnail: '/images/user_sample.jpeg'
+      date: ['2023.03.25', '2023.03.27']
     }
   }
 }

--- a/front/src/stories/components/Tabs/TabHome.stories.tsx
+++ b/front/src/stories/components/Tabs/TabHome.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
         ownerName: 'うさぎ',
         ownerIcon: '/images/user_sample.jpeg'
       }
-    ],
+    ]
   }
 }
 

--- a/front/src/stories/components/Tabs/TabHome.stories.tsx
+++ b/front/src/stories/components/Tabs/TabHome.stories.tsx
@@ -4,15 +4,8 @@ import type { StoryObj, Meta } from '@storybook/react'
 const meta: Meta<typeof TabHome> = {
   component: TabHome,
   argTypes: {
-    userId: {
-      description: '自分のユーザIDが入ります'
-    },
-    myTravelinkList: {
-      description:
-        'ユーザが作成、または、参加中のトラべリンクのリストが入ります'
-    },
-    favoriteList: {
-      description: 'いいねしたみんなのたびトラべリンクのリストが入ります'
+    data: {
+      description: ''
     }
   },
   tags: ['autodocs']
@@ -24,9 +17,7 @@ type Story = StoryObj<typeof TabHome>
 
 export const Default: Story = {
   args: {
-    userId: 'opanchu',
-
-    myTravelinkList: [
+    data: [
       {
         id: 'abc',
         ownerId: 'opanchu',
@@ -46,27 +37,11 @@ export const Default: Story = {
         ownerIcon: '/images/user_sample.jpeg'
       }
     ],
-    favoriteList: [
-      {
-        puclicId: '123',
-        title: 'コスパ重視の京都旅行',
-        tag: ['京都', '3人旅'],
-        thumbnail: '/images/user_sample.jpeg'
-      },
-      {
-        puclicId: '456',
-        title: 'うどん巡り四国旅',
-        tag: ['香川', '徳島', '愛媛', '高知', '2人旅'],
-        thumbnail: '/images/user_sample.jpeg'
-      }
-    ]
   }
 }
 
 export const NoData: Story = {
   args: {
-    userId: 'opanchu',
-    myTravelinkList: [],
-    favoriteList: []
+    data: []
   }
 }

--- a/front/src/stories/components/Tabs/TabHome.stories.tsx
+++ b/front/src/stories/components/Tabs/TabHome.stories.tsx
@@ -5,7 +5,7 @@ const meta: Meta<typeof TabHome> = {
   component: TabHome,
   argTypes: {
     data: {
-      description: ''
+      description: 'travelinkデータの配列'
     }
   },
   tags: ['autodocs']

--- a/front/src/styles/components/Avatars/AvatarWithText.styles.ts
+++ b/front/src/styles/components/Avatars/AvatarWithText.styles.ts
@@ -6,7 +6,7 @@ export const styles = {
     display: flex;
     & > p {
       margin: auto 0;
-      font-size: ${theme.fontSize.sm};
+      font-size: ${theme.fontSize.xs};
     }
   `,
   layoutAvatar: css`

--- a/front/src/styles/components/Buttons/ButtonFill.styles.ts
+++ b/front/src/styles/components/Buttons/ButtonFill.styles.ts
@@ -13,9 +13,7 @@ export const styles = {
     font-size: ${theme.fontSize.md};
     font-weight: 600;
     color: ${theme.color.white};
-    cursor: pointer;
     background-color: ${theme.color.blue};
-    border: 0;
     border-radius: 100px;
     transition: transform 0.1s;
 

--- a/front/src/styles/components/Buttons/ButtonIconRound.styles.ts
+++ b/front/src/styles/components/Buttons/ButtonIconRound.styles.ts
@@ -16,6 +16,8 @@ export const styles = {
     border-radius: 100px;
     box-shadow: 0 1px 3px 1px rgba(101, 119, 134, 0.25);
     transition: transform 0.3s;
+    /* safariでfilterを使うときに必要 */
+    transform: translateZ(0);
 
     &:hover,
     &:focus {

--- a/front/src/styles/components/Buttons/ButtonIconRound.styles.ts
+++ b/front/src/styles/components/Buttons/ButtonIconRound.styles.ts
@@ -11,10 +11,8 @@ export const styles = {
     /* はみ出す波紋を隠す */
     overflow: hidden;
     color: ${theme.color.white};
-    cursor: pointer;
     background-color: ${theme.color.blue};
     filter: drop-shadow(0 0 0.8px rgba(101, 119, 134, 0.2));
-    border: 0;
     border-radius: 100px;
     box-shadow: 0 1px 3px 1px rgba(101, 119, 134, 0.25);
     transition: transform 0.3s;

--- a/front/src/styles/components/Buttons/ButtonIconWithText.styles.ts
+++ b/front/src/styles/components/Buttons/ButtonIconWithText.styles.ts
@@ -24,7 +24,7 @@ export const styles = {
     span {
       display: block;
       margin: 6px 0 0 0;
-      font-size: ${theme.fontSize.sm};
+      font-size: ${theme.fontSize.xs};
     }
   `
 }

--- a/front/src/styles/components/Buttons/ButtonIconWithText.styles.ts
+++ b/front/src/styles/components/Buttons/ButtonIconWithText.styles.ts
@@ -6,7 +6,6 @@ export const styles = {
   wrapper: css`
     min-width: 52px;
     text-align: center;
-    cursor: pointer;
     background-color: ${theme.color.white};
     border: 0;
 

--- a/front/src/styles/components/Buttons/ButtonOutline.styles.ts
+++ b/front/src/styles/components/Buttons/ButtonOutline.styles.ts
@@ -13,7 +13,6 @@ export const styles = {
     font-size: ${theme.fontSize.md};
     font-weight: 600;
     color: ${theme.color.blue};
-    cursor: pointer;
     background-color: ${theme.color.white};
     border: 2px solid ${theme.color.blue};
     border-radius: 100px;

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -14,31 +14,33 @@ export const styles = {
       opacity: 0.9;
     }
   `,
-  imgWrapper: css`
-    width: 100%;
+  imgWrapper: (isGrid: boolean) => css`
+    width: ${isGrid ? '171px' : '100%'};
     height: 171px;
     overflow: hidden;
     /* TODO: 無くなる可能性あり */
     filter: drop-shadow(2px 2px 15px rgba(0, 0, 0, 0.2));
     border: 1px solid ${theme.color.bgGray};
-    border-radius: 16px;
+    border-radius: ${isGrid ? '32px' : '16px'};
   `,
   img: css`
     position: relative !important;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
   `,
-  title: css`
-    margin: 0;
-    font-size: ${theme.fontSize.md};
+  title: (isGrid: boolean) => css`
+    font-size: ${isGrid ? theme.fontSize.sm : theme.fontSize.md};
     font-weight: 600;
   `,
-  description: css`
+  description: (isGrid: boolean) => css`
     margin-top: 16px;
     margin-left: 14px;
+    text-align: ${isGrid ? 'center' : 'start'};
   `,
-  date: css`
-    margin-top: 8px;
-    font-size: ${theme.fontSize.sm};
+  date: (isGrid: boolean) => css`
+    margin-top: ${isGrid ? '6px' : '8px'};
+    font-size: ${theme.fontSize.xs};
     color: ${theme.color.gray};
   `
 }

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react'
 import { theme } from '@/styles/theme'
+import { mq } from '@/styles/utils'
 
 export const styles = {
   wrapper: css`
@@ -17,6 +18,7 @@ export const styles = {
   imgWrapper: (isGrid: boolean) => css`
     width: ${isGrid ? '171px' : '100%'};
     height: 171px;
+    margin: 0 auto;
     overflow: hidden;
     /* TODO: 無くなる可能性あり */
     filter: drop-shadow(2px 2px 15px rgba(0, 0, 0, 0.2));
@@ -24,6 +26,7 @@ export const styles = {
     border-radius: ${isGrid ? '32px' : '16px'};
   `,
   img: css`
+    display: block;
     position: relative !important;
     width: 100%;
     height: 100%;
@@ -35,7 +38,7 @@ export const styles = {
   `,
   description: (isGrid: boolean) => css`
     margin-top: 16px;
-    margin-left: 14px;
+    margin-left: ${isGrid ? '0' : '14px'};
     text-align: ${isGrid ? 'center' : 'start'};
   `,
   date: (isGrid: boolean) => css`

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -3,14 +3,11 @@ import { theme } from '@/styles/theme'
 
 export const styles = {
   wrapper: css`
-    z-index: 1;
     display: block;
     width: 100%;
     height: auto;
     text-decoration: none;
-    background-color: ${theme.color.white};
-    border: 1px solid ${theme.color.outlineGray};
-    border-radius: 16px;
+    cursor: pointer;
     transition: opacity 0.3s 0s ease;
     &:hover,
     &:focus {
@@ -18,35 +15,30 @@ export const styles = {
     }
   `,
   imgWrapper: css`
-    z-index: 1;
     width: 100%;
-    height: 136px;
+    height: 171px;
     overflow: hidden;
-    border-radius: 16px 16px 0 0;
+    /* TODO: 無くなる可能性あり */
+    filter: drop-shadow(2px 2px 15px rgba(0, 0, 0, 0.2));
+    border: 1px solid ${theme.color.bgGray};
+    border-radius: 16px;
   `,
   img: css`
     position: relative !important;
     object-fit: cover;
-  `,
-  content: css`
-    padding: 10px 16px;
-    background-color: ${theme.color.white};
-    border-radius: 0 0 16px 16px;
   `,
   title: css`
     margin: 0;
     font-size: ${theme.fontSize.md};
     font-weight: 600;
   `,
-  day: css`
-    margin: 8px 0 0 0;
+  description: css`
+    margin-top: 16px;
+    margin-left: 14px;
+  `,
+  date: css`
+    margin-top: 8px;
     font-size: ${theme.fontSize.sm};
     color: ${theme.color.gray};
-  `,
-  layoutAvatarWithText: css`
-    margin: 8px 0;
-  `,
-  layoutChipTag: css`
-    margin: 8px 0;
   `
 }

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -13,18 +13,14 @@ export const styles = {
       opacity: 0.9;
     }
   `,
-  imgWrapper: (isSquare: boolean) => css`
+  imgWrapper: (isGrid: boolean) => css`
     position: relative;
     width: 100%;
-    height: ${isSquare ? '100%' : '171px'};
+    height: ${isGrid ? '100%' : '171px'};
     margin: 0 auto;
     overflow: hidden;
-    /* TODO: 無くなる可能性あり */
-    filter: drop-shadow(2px 2px 15px rgba(0, 0, 0, 0.2));
     border: 1px solid ${theme.color.bgGray};
-    border-radius: ${isSquare ? '32px' : '16px'};
-    /* safariでfilterを使うときに必要 */
-    transform: translateZ(0);
+    border-radius: ${isGrid ? '32px' : '16px'};
   `,
   imgSquare: css`
     /* 正方形を維持する */
@@ -38,17 +34,17 @@ export const styles = {
     object-fit: cover;
     display: block;
   `,
-  title: (isSquare: boolean) => css`
-    font-size: ${isSquare ? theme.fontSize.sm : theme.fontSize.md};
+  title: (isGrid: boolean) => css`
+    font-size: ${isGrid ? theme.fontSize.sm : theme.fontSize.md};
     font-weight: 600;
   `,
-  description: (isSquare: boolean) => css`
+  description: (isGrid: boolean) => css`
     margin-top: 16px;
-    margin-left: ${isSquare ? '0' : '14px'};
-    text-align: ${isSquare ? 'center' : 'start'};
+    margin-left: ${isGrid ? '0' : '14px'};
+    text-align: ${isGrid ? 'center' : 'start'};
   `,
-  date: (isSquare: boolean) => css`
-    margin-top: ${isSquare ? '6px' : '8px'};
+  date: (isGrid: boolean) => css`
+    margin-top: ${isGrid ? '6px' : '8px'};
     font-size: ${theme.fontSize.xs};
     color: ${theme.color.gray};
   `

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -13,16 +13,20 @@ export const styles = {
       opacity: 0.9;
     }
   `,
-  imgWrapper: (isGrid: boolean) => css`
+  imgWrapper: (isSquare: boolean) => css`
+    position: relative;
     width: 100%;
-    height: ${isGrid ? '100%' : '171px'};
+    height: ${isSquare ? '100%' : '171px'};
     margin: 0 auto;
     overflow: hidden;
     /* TODO: 無くなる可能性あり */
     filter: drop-shadow(2px 2px 15px rgba(0, 0, 0, 0.2));
     border: 1px solid ${theme.color.bgGray};
-    border-radius: ${isGrid ? '32px' : '16px'};
-
+    border-radius: ${isSquare ? '32px' : '16px'};
+    /* safariでfilterを使うときに必要 */
+    transform: translateZ(0);
+  `,
+  imgSquare: css`
     /* 正方形を維持する */
     &::before {
       display: block;
@@ -31,19 +35,20 @@ export const styles = {
     }
   `,
   img: css`
-    object-fit: cover !important;
+    object-fit: cover;
+    display: block;
   `,
-  title: (isGrid: boolean) => css`
-    font-size: ${isGrid ? theme.fontSize.sm : theme.fontSize.md};
+  title: (isSquare: boolean) => css`
+    font-size: ${isSquare ? theme.fontSize.sm : theme.fontSize.md};
     font-weight: 600;
   `,
-  description: (isGrid: boolean) => css`
+  description: (isSquare: boolean) => css`
     margin-top: 16px;
-    margin-left: ${isGrid ? '0' : '14px'};
-    text-align: ${isGrid ? 'center' : 'start'};
+    margin-left: ${isSquare ? '0' : '14px'};
+    text-align: ${isSquare ? 'center' : 'start'};
   `,
-  date: (isGrid: boolean) => css`
-    margin-top: ${isGrid ? '6px' : '8px'};
+  date: (isSquare: boolean) => css`
+    margin-top: ${isSquare ? '6px' : '8px'};
     font-size: ${theme.fontSize.xs};
     color: ${theme.color.gray};
   `

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -16,8 +16,12 @@ export const styles = {
     }
   `,
   imgWrapper: (isGrid: boolean) => css`
-    width: ${isGrid ? '171px' : '100%'};
-    height: 171px;
+    width: ${isGrid ? '160px' : '100%'};
+    height: 160px;
+    ${mq('xs')} {
+      width: ${isGrid ? '150px' : '100%'};
+      height: ${isGrid ? '150px' : '171px'};
+    }
     margin: 0 auto;
     overflow: hidden;
     /* TODO: 無くなる可能性あり */
@@ -26,8 +30,8 @@ export const styles = {
     border-radius: ${isGrid ? '32px' : '16px'};
   `,
   img: css`
-    display: block;
     position: relative !important;
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;

--- a/front/src/styles/components/Cards/CardTravelink.styles.ts
+++ b/front/src/styles/components/Cards/CardTravelink.styles.ts
@@ -1,12 +1,10 @@
 import { css } from '@emotion/react'
 import { theme } from '@/styles/theme'
-import { mq } from '@/styles/utils'
 
 export const styles = {
   wrapper: css`
     display: block;
     width: 100%;
-    height: auto;
     text-decoration: none;
     cursor: pointer;
     transition: opacity 0.3s 0s ease;
@@ -16,25 +14,24 @@ export const styles = {
     }
   `,
   imgWrapper: (isGrid: boolean) => css`
-    width: ${isGrid ? '160px' : '100%'};
-    height: 160px;
-    ${mq('xs')} {
-      width: ${isGrid ? '150px' : '100%'};
-      height: ${isGrid ? '150px' : '171px'};
-    }
+    width: 100%;
+    height: ${isGrid ? '100%' : '171px'};
     margin: 0 auto;
     overflow: hidden;
     /* TODO: 無くなる可能性あり */
     filter: drop-shadow(2px 2px 15px rgba(0, 0, 0, 0.2));
     border: 1px solid ${theme.color.bgGray};
     border-radius: ${isGrid ? '32px' : '16px'};
+
+    /* 正方形を維持する */
+    &::before {
+      display: block;
+      padding-top: 100%;
+      content: '';
+    }
   `,
   img: css`
-    position: relative !important;
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    object-fit: cover !important;
   `,
   title: (isGrid: boolean) => css`
     font-size: ${isGrid ? theme.fontSize.sm : theme.fontSize.md};

--- a/front/src/styles/components/Chips/ChipTag.styles.ts
+++ b/front/src/styles/components/Chips/ChipTag.styles.ts
@@ -11,7 +11,7 @@ export const styles = {
   chip: css`
     padding: 8px;
     margin: 8px 8px 0 0;
-    font-size: ${theme.fontSize.sm};
+    font-size: ${theme.fontSize.xs};
     background-color: ${theme.color.bgGray};
     border-radius: 4px;
   `

--- a/front/src/styles/components/Icons/IconWithText.styles.ts
+++ b/front/src/styles/components/Icons/IconWithText.styles.ts
@@ -5,7 +5,7 @@ export const styles = {
   wrapper: css`
     width: 80px;
     padding: 10px 0;
-    font-size: ${theme.fontSize.sm};
+    font-size: ${theme.fontSize.xs};
     text-align: center;
     text-decoration: none;
     background-color: ${theme.color.white};

--- a/front/src/styles/components/Modals/BaseHalfModal.styles.ts
+++ b/front/src/styles/components/Modals/BaseHalfModal.styles.ts
@@ -42,9 +42,7 @@ export const styles = {
     width: 40px;
     height: 40px;
     text-align: right;
-    cursor: pointer;
     background-color: ${theme.color.white};
-    border: 0;
     border-radius: 50%;
 
     /* 本来は:focusも一緒につけた方がいいけど，focus-trapでモーダル開いた時に直近の要素にfocusが当たる（ばつボタンにfocusのstyleが当たる）のがなんか微妙なのでstyleは当てないようにした */

--- a/front/src/styles/components/Navigations/NavigationBottom.styles.ts
+++ b/front/src/styles/components/Navigations/NavigationBottom.styles.ts
@@ -22,7 +22,7 @@ export const styles = {
   `,
   nav: css`
     width: 100%;
-    font-size: ${theme.fontSize.sm};
+    font-size: ${theme.fontSize.xs};
     text-align: center;
     list-style: none;
     p {

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -3,7 +3,7 @@ import { theme } from '@/styles/theme'
 
 export const styles = {
   layoutCardTravelink: css`
-    margin-bottom: 16px;
+    margin-bottom: 32px;
   `,
   tabs: css`
     position: relative;

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -3,13 +3,13 @@ import { theme } from '@/styles/theme'
 import { mq } from '@/styles/utils'
 
 export const styles = {
-  grid: (isGrid: boolean) => css`
+  grid: (isSquare: boolean) => css`
     display: grid;
-    grid-template-columns: ${isGrid ? '1fr 1fr 1fr' : '1fr'};
+    grid-template-columns: ${isSquare ? '1fr 1fr 1fr' : '1fr'};
     gap: 32px 16px;
     width: 100%;
     ${mq('sm')} {
-      grid-template-columns: ${isGrid ? '1fr 1fr' : '1fr'};
+      grid-template-columns: ${isSquare ? '1fr 1fr' : '1fr'};
     }
   `,
   layoutCardTravelink: css`

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -22,8 +22,13 @@ export const styles = {
     margin-bottom: 16px;
   `,
   buttonGrid: css`
+    color: ${theme.color.black};
     background-color: transparent;
     border: none;
+    &:hover,
+    &:focus {
+      color: ${theme.color.blue};
+    }
   `,
   tabs: css`
     position: relative;

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -22,7 +22,7 @@ export const styles = {
     margin-bottom: 16px;
   `,
   buttonGrid: css`
-    background-color: ${theme.color.white};
+    background-color: transparent;
     border: none;
   `,
   tabs: css`

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -15,11 +15,20 @@ export const styles = {
   layoutCardTravelink: css`
     margin-bottom: 32px;
   `,
+  tabsWrapper: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  `,
+  buttonGrid: css`
+    background-color: ${theme.color.white};
+    border: none;
+  `,
   tabs: css`
     position: relative;
     width: 100%;
     height: 34px;
-    margin-bottom: 16px;
     & input[type='radio'] {
       /* ラジオボタン消す */
       display: none;

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -26,10 +26,10 @@ export const styles = {
     background-color: transparent;
     border: none;
     &:hover {
-      color: ${theme.color.black};
+      color: ${theme.color.blue};
     }
     &:focus {
-      color: ${theme.color.blue};
+      color: ${theme.color.black};
     }
   `,
   tabs: css`

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -6,6 +6,8 @@ export const styles = {
   grid: (isGrid: boolean) => css`
     display: grid;
     grid-template-columns: ${isGrid ? '1fr 1fr 1fr' : '1fr'};
+    gap: 32px 16px;
+    width: 100%;
     ${mq('sm')} {
       grid-template-columns: ${isGrid ? '1fr 1fr' : '1fr'};
     }

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -3,13 +3,13 @@ import { theme } from '@/styles/theme'
 import { mq } from '@/styles/utils'
 
 export const styles = {
-  grid: (isSquare: boolean) => css`
+  grid: (isGrid: boolean) => css`
     display: grid;
-    grid-template-columns: ${isSquare ? '1fr 1fr 1fr' : '1fr'};
+    grid-template-columns: ${isGrid ? '1fr 1fr 1fr' : '1fr'};
     gap: 32px 16px;
     width: 100%;
     ${mq('sm')} {
-      grid-template-columns: ${isSquare ? '1fr 1fr' : '1fr'};
+      grid-template-columns: ${isGrid ? '1fr 1fr' : '1fr'};
     }
   `,
   layoutCardTravelink: css`

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -25,7 +25,9 @@ export const styles = {
     color: ${theme.color.black};
     background-color: transparent;
     border: none;
-    &:hover,
+    &:hover {
+      color: ${theme.color.black};
+    }
     &:focus {
       color: ${theme.color.blue};
     }

--- a/front/src/styles/components/Tabs/TabHome.styles.ts
+++ b/front/src/styles/components/Tabs/TabHome.styles.ts
@@ -1,7 +1,15 @@
 import { css } from '@emotion/react'
 import { theme } from '@/styles/theme'
+import { mq } from '@/styles/utils'
 
 export const styles = {
+  grid: (isGrid: boolean) => css`
+    display: grid;
+    grid-template-columns: ${isGrid ? '1fr 1fr 1fr' : '1fr'};
+    ${mq('sm')} {
+      grid-template-columns: ${isGrid ? '1fr 1fr' : '1fr'};
+    }
+  `,
   layoutCardTravelink: css`
     margin-bottom: 32px;
   `,

--- a/front/src/styles/globalStyle.ts
+++ b/front/src/styles/globalStyle.ts
@@ -27,4 +27,10 @@ export const globalStyle = () => css`
     font-family: inherit;
     font-size: 100%;
   }
+
+  button {
+    cursor: pointer;
+    background-color: transparent;
+    border: none;
+  }
 `

--- a/front/src/styles/pages/mypage/index.styles.ts
+++ b/front/src/styles/pages/mypage/index.styles.ts
@@ -22,7 +22,7 @@ export const styles = {
     }
     & > p {
       margin: 16px 0;
-      font-size: ${theme.fontSize.sm};
+      font-size: ${theme.fontSize.xs};
     }
   `
 }

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -21,6 +21,7 @@ const fontSize = {
 } as const
 
 const breakpoint = {
+  xs: '27rem',
   sm: '32rem',
   md: '68rem'
 } as const

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -13,7 +13,8 @@ const color = {
 } as const
 
 const fontSize = {
-  sm: '1.2rem',
+  xs: '1.2rem',
+  sm: '1.4rem',
   md: '1.6rem',
   lg: '2.0rem',
   xl: '2.4rem'


### PR DESCRIPTION
## 💫 関連Issues
close #84 

## 💪🏻 変更したこと
- /homeのリスト表示とグリッド表示を切り替えれるようにした
- 毎回buttonにcursor pointerとかborder 0とか面倒なのでglobal styleにして指定してるところは消した

## 👀 確認項目
- http://localhost:3000/home
- 切り替えボタンのhoverのstyleどうしますー？

## 📸 スクリーンショット
<img width="708" alt="スクリーンショット 2023-04-26 12 10 30" src="https://user-images.githubusercontent.com/67625825/234459172-e35622f5-fe21-4011-a183-348ffc21fe28.png">
<img width="468" alt="スクリーンショット 2023-04-26 12 10 42" src="https://user-images.githubusercontent.com/67625825/234459235-38ea2ceb-150f-4732-bb45-ee8027c601dc.png">
<img width="590" alt="スクリーンショット 2023-04-26 12 10 58" src="https://user-images.githubusercontent.com/67625825/234459324-02cb2013-5e18-4752-8541-f4ee3d62426d.png">


## 🙈 self review
- [x] 必要のないCSSはないか（特にサイトからコピペした場合注意）
- [x] The Nu Html Checkerでエラーがでていないこと
