### PR TITLE
ボトムナビゲーションの後ろの要素が隠れる

### DIFF
--- a/front/src/components/Navigations/NavigationBottom.tsx
+++ b/front/src/components/Navigations/NavigationBottom.tsx
@@ -15,8 +15,8 @@ export const NavigationBottom = () => {
   const currentPath = router.pathname
 
   return (
-    <nav>
-      <ul css={styles.wrapper}>
+    <nav css={styles.wrapper}>
+      <ul css={styles.ul}>
         <li css={styles.nav}>
           <Link
             css={[styles.navItem, currentPath === '/home' && styles.focus]}

--- a/front/src/styles/components/Navigations/NavigationBottom.styles.ts
+++ b/front/src/styles/components/Navigations/NavigationBottom.styles.ts
@@ -3,7 +3,8 @@ import { theme } from '@/styles/theme'
 
 export const styles = {
   wrapper: css`
-    height: 120px;
+    /* height 80px + margin 32px */
+    height: 112px;
     background-color: ${theme.color.white};
   `,
   ul: css`

--- a/front/src/styles/components/Navigations/NavigationBottom.styles.ts
+++ b/front/src/styles/components/Navigations/NavigationBottom.styles.ts
@@ -3,6 +3,10 @@ import { theme } from '@/styles/theme'
 
 export const styles = {
   wrapper: css`
+    height: 120px;
+    background-color: ${theme.color.white};
+  `,
+  ul: css`
     position: fixed;
     bottom: 0;
     z-index: 100;


### PR DESCRIPTION
## 💫 関連Issues
close #89 

## 💪🏻 変更したこと
- navの外側にheightつける

## 👀 確認項目
- http://localhost:3000/home

## 📸 スクリーンショット
- 
<img width="841" alt="スクリーンショット 2023-04-26 23 45 17" src="https://user-images.githubusercontent.com/67625825/234612856-1a0f0d7f-b4bd-4f88-8442-9583f183f2fc.png">


## 🙈 self review
- [x] 必要のないCSSはないか（特にサイトからコピペした場合注意）
- [x] The Nu Html Checkerでエラーがでていないこと
